### PR TITLE
Exposing email auth to API calls

### DIFF
--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -1,3 +1,4 @@
+import socket
 from flask import Flask, request, jsonify, make_response, g
 from flask.ext.restful import reqparse
 from werkzeug.exceptions import default_exceptions, HTTPException
@@ -6,15 +7,26 @@ from sqlalchemy.orm.exc import NoResultFound
 from inbox.api.kellogs import APIEncoder
 from nylas.logging import get_logger
 from inbox.models import Namespace, Account
-from inbox.models.session import global_session_scope
+from inbox.models.session import global_session_scope, session_scope
 from inbox.api.validation import (bounded_str, ValidatableArgument,
                                   strict_parse_args, limit)
 from inbox.api.validation import valid_public_id
+
+from inbox.util.url import provider_from_address
+from inbox.auth.base import handler_from_provider
+from inbox.models.backends.gmail import GmailAccount
+
+from imapclient import IMAPClient
+from inbox.auth.generic import create_imap_connection
+from inbox.basicauth import (ConnectionError, NotSupportedError,
+                             SSLNotSupportedError, OAuthError)
+from inbox.sendmail.smtp.postel import SMTPConnection
 
 from ns_api import app as ns_api
 from ns_api import DEFAULT_LIMIT
 
 from inbox.webhooks.gpush_notifications import app as webhooks_api
+
 
 app = Flask(__name__)
 # Handle both /endpoint and /endpoint/ without redirecting.
@@ -41,6 +53,7 @@ for code in default_exceptions.iterkeys():
 def auth():
     """ Check for account ID on all non-root URLS """
     if request.path in ('/accounts', '/accounts/', '/') \
+            or request.path.startswith('/new_user') \
             or request.path.startswith('/w/'):
         return
 
@@ -96,7 +109,7 @@ def ns_all():
     """ Return all namespaces """
     # We do this outside the blueprint to support the case of an empty
     # public_id.  However, this means the before_request isn't run, so we need
-    # to make our own session
+    # to make our own session.
     with global_session_scope() as db_session:
         parser = reqparse.RequestParser(argument_class=ValidatableArgument)
         parser.add_argument('limit', default=DEFAULT_LIMIT, type=limit,
@@ -117,6 +130,170 @@ def ns_all():
         namespaces = query.all()
         encoder = APIEncoder()
         return encoder.jsonify(namespaces)
+
+
+@app.route('/new_user/', methods=['POST'])
+def add_new_user():
+    response = {}
+    encoder = APIEncoder()
+
+    data = request.get_json(force=True)
+    email_address = data.get('email_address')
+    password = data.get('password')
+    auth_details = data.get('auth_details')
+    reauth = data.get('reauth')
+    target = data.get('target', 0)
+
+    if not email_address:
+        response['error'] = 'Missing key - "email_address"!'
+        return encoder.jsonify(response)
+
+    shard_id = target << 48
+
+    with session_scope(shard_id) as db_session:
+        account = db_session.query(Account).filter_by(
+            email_address=email_address).first()
+        if account is not None and not reauth:
+            response['error'] = 'Already have this account!'
+            return encoder.jsonify(response)
+
+        auth_info = {}
+        provider = provider_from_address(email_address)
+        if 'gmail' in provider:
+            auth_handler = handler_from_provider(provider)
+            response['oauth_url'] = auth_handler.get_oauth_url(email_address)
+            response['links'] = {'confirm_url': request.url + '/confirm_oauth'}
+            namespace = Namespace()
+            account = GmailAccount(namespace=namespace)
+            account.sync_should_run = False
+            account.refresh_token = '_placeholder_'
+            account.email_address = email_address
+        else:
+            if not password:
+                response['error'] = 'Missing key - "password"!'
+                return encoder.jsonify(response)
+            auth_info['email'] = email_address
+            auth_info['password'] = password
+            if provider != 'unknown':
+                auth_handler = handler_from_provider(provider)
+                auth_info['provider'] = provider
+                try:
+                    if reauth:
+                        account = auth_handler.update_account(account, auth_info)
+                    else:
+                        account = auth_handler.create_account(email_address, auth_info)
+                except Exception as e:
+                    response['error'] = e.msg
+            else:
+                auth_info['provider'] = 'custom'
+                auth_handler = handler_from_provider('custom')
+                if not auth_details:
+                    auth_info.update(try_fill_config_data(email_address, password))
+                else:
+                    auth_info.update(auth_details)
+                try:
+                    if reauth:
+                        account = auth_handler.update_account(account, auth_info)
+                    else:
+                        account = auth_handler.create_account(email_address, auth_info)
+                except Exception as e:
+                    response['error'] = str(e)
+            try:
+                auth_handler.verify_account(account)
+                response['data'] = 'OK. Authenticated account for {}'.format(email_address)
+            except Exception as e:
+                response['error'] = str(e)
+        db_session.add(account)
+        db_session.commit()
+    return encoder.jsonify(response)
+
+
+def try_fill_config_data(email_address, password):
+    response = {}
+    subdomains = ['mail.', 'imap.', 'smtp.', '']
+    domain = email_address.split('@')[1].lower()
+    smtp_port = 587
+    imap_port = 993
+    log = get_logger()
+
+    for imap_host in [subdomain + domain for subdomain in subdomains]:
+        try:
+            create_imap_connection(imap_host, imap_port, True, use_timeout=10)
+            response['imap_server_host'] = imap_host
+            response['imap_server_port'] = imap_port
+            break
+        except SSLNotSupportedError:
+            create_imap_connection(imap_host, imap_port, False, use_timeout=10)
+            response['imap_server_host'] = imap_host
+            response['imap_server_port'] = imap_port
+            response['ssl_required'] = False
+            break
+        except (IMAPClient.Error, socket.error):
+            continue
+    if 'imap_server_host' not in response:
+        raise ConnectionError('IMAP connection failed. Check your password. '
+                              'If error persists try provide connection details')
+    for smtp_host in [subdomain + domain for subdomain in subdomains]:
+        try:
+            with SMTPConnection(0, email_address, email_address, 'password', password,
+                                (smtp_host, smtp_port), True, log):
+                response['smtp_server_host'] = smtp_host
+                response['smtp_server_port'] = smtp_port
+                break
+        except:
+            continue
+    if 'smtp_server_host' not in response:
+        raise ConnectionError('SMTP connection failed. Check your password. '
+                              'If error persists try provide connection details')
+    return response
+
+
+@app.route('/new_user/confirm_oauth/', methods=['POST'])
+def confim_oauth_user():
+    response = {}
+    encoder = APIEncoder()
+    data = request.get_json(force=True)
+    email_address = data.get('email_address')
+    token = data.get('token')
+    target = data.get('target', 0)
+
+    if not email_address:
+        response['error'] = 'Missing key - "email_address"!'
+        return encoder.jsonify(response)
+    if not token:
+        response['error'] = 'Missing key - "token"!'
+        return encoder.jsonify(response)
+
+    shard_id = target << 48
+
+    with session_scope(shard_id) as db_session:
+        account = db_session.query(Account).filter_by(
+            email_address=email_address).first()
+        if account is None:
+            response['error'] = 'Don\'t have this account!'
+            return encoder.jsonify(response)
+        auth_info = {}
+        provider = provider_from_address(email_address)
+        auth_info['provider'] = provider
+        auth_handler = handler_from_provider(provider)
+        try:
+            auth_response = auth_handler._get_authenticated_user(token)
+            auth_response['contacts'] = True
+            auth_response['events'] = True
+            auth_info.update(auth_response)
+        except OAuthError:
+            response['error'] = "Invalid authorization code, try again..."
+            return encoder.jsonify(response)
+        account = auth_handler.update_account(account, auth_info)
+        try:
+            if auth_handler.verify_account(account):
+                db_session.add(account)
+                db_session.commit()
+                response['data'] = 'OK. Authenticated account for {}'.format(email_address)
+        except NotSupportedError as e:
+            response['error'] = str(e)
+            return encoder.jsonify(response)
+    return encoder.jsonify(response)
 
 
 @app.route('/logout')

--- a/inbox/auth/gmail.py
+++ b/inbox/auth/gmail.py
@@ -223,14 +223,7 @@ class GmailAuthHandler(OAuthAuthHandler):
         return validation_dict
 
     def interactive_auth(self, email_address=None):
-        url_args = {'redirect_uri': self.OAUTH_REDIRECT_URI,
-                    'client_id': self.OAUTH_CLIENT_ID,
-                    'response_type': 'code',
-                    'scope': self.OAUTH_SCOPE,
-                    'access_type': 'offline'}
-        if email_address:
-            url_args['login_hint'] = email_address
-        url = url_concat(self.OAUTH_AUTHENTICATE_URL, url_args)
+        url = self.get_oauth_url(email_address)
 
         print 'To authorize Nylas, visit this URL and follow the directions:'
         print '\n{}'.format(url)
@@ -245,6 +238,19 @@ class GmailAuthHandler(OAuthAuthHandler):
             except OAuthError:
                 print "\nInvalid authorization code, try again...\n"
                 auth_code = None
+
+
+    def get_oauth_url(self, email_address=None):
+        url_args = {'redirect_uri': self.OAUTH_REDIRECT_URI,
+                    'client_id': self.OAUTH_CLIENT_ID,
+                    'response_type': 'code',
+                    'scope': self.OAUTH_SCOPE,
+                    'access_type': 'offline'}
+        if email_address:
+            url_args['login_hint'] = email_address
+        url = url_concat(self.OAUTH_AUTHENTICATE_URL, url_args)
+
+        return url
 
 
 def _process_imap_exception(exc):

--- a/inbox/sendmail/message.py
+++ b/inbox/sendmail/message.py
@@ -20,7 +20,7 @@ from flanker import mime
 from flanker.addresslib import address
 from flanker.addresslib.quote import smart_quote
 from flanker.mime.message.headers.encoding import encode_string
-from flanker.addresslib.parser import MAX_ADDRESS_LENGTH
+from flanker.addresslib.address import MAX_ADDRESS_LENGTH
 from html2text import html2text
 
 VERSION = pkg_resources.get_distribution('inbox-sync').version


### PR DESCRIPTION
Fixes #

Summary:
/new_user API endpoint created that supports POST requests and expects to get "email_address" and/or "password" fields for non Google emails. 
Test Plan:
Unit tests are not implemented yet.
Reviewers:
Please add the reviewer as an assignee to this PR on the right
